### PR TITLE
Standalone wasi stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ test/lit/lit.site.cfg.py
 # files related to VS Code
 /.history
 /.vscode
+
+/wasi-stub/wasi-stub

--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,3 @@ test/lit/lit.site.cfg.py
 # files related to VS Code
 /.history
 /.vscode
-
-/wasi-stub/wasi-stub

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -4348,8 +4348,8 @@ void BinaryenFunctionImportToFunction(BinaryenFunctionRef import) {
   auto* func = (Function*)import;
   if (func->imported()) {
     func->module = Name();
-    func->name = Name();
     func->base = Name();
+    func->setExplicitName(func->name);
   }
 }
 const char* BinaryenTableImportGetBase(BinaryenTableRef import) {

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -4344,6 +4344,14 @@ const char* BinaryenFunctionImportGetBase(BinaryenFunctionRef import) {
     return "";
   }
 }
+void BinaryenFunctionImportToFunction(BinaryenFunctionRef import) {
+  auto* func = (Function*)import;
+  if (func->imported()) {
+    func->module = Name();
+    func->name = Name();
+    func->base = Name();
+  }
+}
 const char* BinaryenTableImportGetBase(BinaryenTableRef import) {
   auto* table = (Table*)import;
   if (table->imported()) {

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -2131,6 +2131,7 @@ BINARYEN_API void BinaryenAddFunctionImport(BinaryenModuleRef module,
                                             const char* externalBaseName,
                                             BinaryenType params,
                                             BinaryenType results);
+BINARYEN_API void BinaryenFunctionImportToFunction(BinaryenFunctionRef import);
 BINARYEN_API void BinaryenAddTableImport(BinaryenModuleRef module,
                                          const char* internalName,
                                          const char* externalModuleName,

--- a/wasi-stub/.gitignore
+++ b/wasi-stub/.gitignore
@@ -1,0 +1,1 @@
+wasi-stub

--- a/wasi-stub/README.md
+++ b/wasi-stub/README.md
@@ -1,0 +1,18 @@
+# WASI-STUB
+
+This tool takes a wasm file, replace all `wasi_snapshot_preview1` import to (stub) functions defines in the same module. This is useful when executing wasm in sandbox enviroment where wasi is not available.
+
+## Build
+
+First build binaryen with `cmake . && make -j`. Then:
+```
+./build.sh
+```
+
+## Use
+
+```
+./run.sh file.wasm
+```
+
+The tool will write file.wasm inplace.

--- a/wasi-stub/build.sh
+++ b/wasi-stub/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gcc -I../src wasi-stub.c -L../lib -lbinaryen -lpthread -o wasi-stub

--- a/wasi-stub/run.sh
+++ b/wasi-stub/run.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-export LD_LIBRARY_PATH=${SCRIPT_DIR}/../lib
+SYSTEM=$(uname)
+if [ "${SYSTEM}" = "Linux" ]; then
+    export LD_LIBRARY_PATH=${SCRIPT_DIR}/../lib
+elif [ "${SYSTEM}" = "Darwin" ]; then
+    export DYLD_LIBRARY_PATH=${SCRIPT_DIR}/../lib
+else
+    echo "Unsupported system ${SYSTEM}"
+    exit 1
+fi
 ${SCRIPT_DIR}/wasi-stub $@

--- a/wasi-stub/run.sh
+++ b/wasi-stub/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export LD_LIBRARY_PATH=$(pwd)/../lib
+./wasi-stub $@

--- a/wasi-stub/run.sh
+++ b/wasi-stub/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-LD_LIBRARY_PATH=${SCRIPT_DIR}/../lib
+export LD_LIBRARY_PATH=${SCRIPT_DIR}/../lib
 ${SCRIPT_DIR}/wasi-stub $@

--- a/wasi-stub/run.sh
+++ b/wasi-stub/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
-export LD_LIBRARY_PATH=$(pwd)/../lib
-./wasi-stub $@
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+LD_LIBRARY_PATH=${SCRIPT_DIR}/../lib
+${SCRIPT_DIR}/wasi-stub $@

--- a/wasi-stub/wasi-stub.c
+++ b/wasi-stub/wasi-stub.c
@@ -1,0 +1,44 @@
+#include <binaryen-c.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(int argc, char *argv[]) {
+  FILE *input;
+  input = fopen(argv[1], "rb");
+  fseek( input, 0, SEEK_END );
+  size_t size = ftell(input);
+  fseek( input, 0, SEEK_SET );
+  char *buf = malloc(size);
+  fread(buf, size, 1, input);
+  fclose(input);
+  BinaryenModuleRef module = BinaryenModuleRead(buf, size);
+  // Optimization, wasi imports are consequtive
+  int visitWasi = 0;
+
+  BinaryenIndex numFunctions = BinaryenGetNumFunctions(module);
+  for (BinaryenIndex i = 0; i < numFunctions; i++) {
+    BinaryenFunctionRef fid = BinaryenGetFunctionByIndex(module, i);
+    if (strcmp(BinaryenFunctionImportGetModule(fid), "wasi_snapshot_preview1") == 0) {
+      visitWasi = 1;
+      printf("%s\n", BinaryenFunctionImportGetBase(fid));
+      BinaryenFunctionImportToFunction(fid);
+    } else if (visitWasi) {
+      break;
+    }
+  }
+  size_t output_size = 2*size;
+  char* output_buf = malloc(output_size);
+  size_t output_actual_size = BinaryenModuleWrite(module, output_buf, output_size);
+  FILE *output;
+  output = fopen(argv[1], "wb");
+  fwrite(output_buf, output_actual_size, 1, output);
+  fclose(output);
+  free(output_buf);
+
+  // Clean up the module, which owns all the objects we created above
+  BinaryenModuleDispose(module);
+  free(buf);
+
+  return 0;
+}

--- a/wasi-stub/wasi-stub.c
+++ b/wasi-stub/wasi-stub.c
@@ -4,12 +4,26 @@
 #include <string.h>
 
 int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    fprintf(stderr, "Usage: wasi-stub file.wasm\n");
+    exit(1);
+  }
+
   FILE *input;
   input = fopen(argv[1], "rb");
+  if (input == NULL) {
+    fprintf(stderr, "Unable to open %s\n", argv[1]);
+    exit(1);
+  }
+
   fseek( input, 0, SEEK_END );
   size_t size = ftell(input);
   fseek( input, 0, SEEK_SET );
   char *buf = malloc(size);
+  if (buf == NULL) {
+    fprintf(stderr, "Unable to alloc buffer to read.\n");
+    exit(1);
+  }
   fread(buf, size, 1, input);
   fclose(input);
   BinaryenModuleRef module = BinaryenModuleRead(buf, size);
@@ -21,17 +35,35 @@ int main(int argc, char *argv[]) {
     BinaryenFunctionRef fid = BinaryenGetFunctionByIndex(module, i);
     if (strcmp(BinaryenFunctionImportGetModule(fid), "wasi_snapshot_preview1") == 0) {
       visitWasi = 1;
-      printf("%s\n", BinaryenFunctionImportGetBase(fid));
+      printf("Find and stub wasi import: %s.\n", BinaryenFunctionImportGetBase(fid));
+      BinaryenType retType = BinaryenFunctionGetResults(fid);
       BinaryenFunctionImportToFunction(fid);
+
+      if (BinaryenTypeArity(retType) == 0) {
+        BinaryenExpressionRef noop = BinaryenNop(module);
+        BinaryenFunctionSetBody(fid, noop);        
+      } else {
+        BinaryenExpressionRef ret = BinaryenReturn(module, BinaryenConst(module, BinaryenLiteralInt32(76)));
+        BinaryenFunctionSetBody(fid, ret);
+      }
     } else if (visitWasi) {
       break;
     }
   }
+
   size_t output_size = 2*size;
   char* output_buf = malloc(output_size);
+  if (output_buf == NULL) {
+    fprintf(stderr, "Unable to alloc buffer to write.\n");
+    exit(1);
+  }
   size_t output_actual_size = BinaryenModuleWrite(module, output_buf, output_size);
   FILE *output;
   output = fopen(argv[1], "wb");
+  if (output == NULL) {
+    fprintf(stderr, "Unable to open %s for write\n", argv[1]);
+    exit(1);
+  }
   fwrite(output_buf, output_actual_size, 1, output);
   fclose(output);
   free(output_buf);


### PR DESCRIPTION
@ailisp you have added `BinaryenFunctionImportToFunction` in order to make it work, we will not be able to use `binaryen` as a dependency for `wasi-stub`. So, it will remain a fork.